### PR TITLE
Migrate fbw: test expectedHost/expectedNetwork handling

### DIFF
--- a/plugins/lime-plugin-fbw/src/FbwPage.js
+++ b/plugins/lime-plugin-fbw/src/FbwPage.js
@@ -1,7 +1,7 @@
 import { h, Fragment } from 'preact';
 import { useState, useEffect } from 'preact/hooks';
 
-import './style';
+import './style.less';
 
 import SelectAction from './containers/SelectAction';
 import { NetworkForm } from './containers/NetworkForm';

--- a/plugins/lime-plugin-fbw/src/FbwPage.spec.js
+++ b/plugins/lime-plugin-fbw/src/FbwPage.spec.js
@@ -1,0 +1,70 @@
+import { h } from "preact";
+import FbwPage from './FbwPage';
+import { fireEvent, screen } from '@testing-library/preact';
+import '@testing-library/jest-dom';
+import { render, flushPromises } from 'utils/test_utils';
+import { AppContextProvider } from 'utils/app.context';
+import { createNetwork } from './FbwApi';
+import { enableFetchMocks } from 'jest-fetch-mock';
+
+jest.mock('./FbwApi');
+enableFetchMocks()
+
+const advanceToChecking = async () => {
+    fireEvent.click(
+        await screen.findByRole('button', { name: /Create new network/i })
+    );
+    fireEvent.input(
+        await screen.findByLabelText('Choose a name for your network'),
+        { target: { value: 'ournetwork' } }
+    );
+    fireEvent.input(
+        await screen.findByLabelText('Choose a shared password for network administration'),
+        { target: { value: 'somepassword123' } }
+    );
+    fireEvent.input(
+        await screen.findByLabelText('Re-enter the shared password'),
+        { target: { value: 'somepassword123' } }
+    );
+    fireEvent.input(
+        await screen.findByLabelText('Choose a name for this node'),
+        { target: { value: 'mynode' } }
+    );
+    fireEvent.click(
+        await screen.findByRole('button', { name: /Create network/i })
+    );
+    // fastforward 125 seconds of waiting time...
+    for (let i = 0; i < 125; i++) {
+        jest.advanceTimersByTime(1000);
+        await flushPromises();
+    }
+}
+
+describe('Fbw Page', () => {
+    beforeEach(() => {
+        fetch.resetMocks();
+        createNetwork.mockImplementation(async () => ({ status: 'done' }));
+    })
+
+    beforeAll(() => {
+        jest.useFakeTimers();
+    });
+
+    afterAll(() => {
+        jest.useRealTimers();
+    })
+
+    it('asks to connect to the wifi network for this node if cannot get hostname', async () => {
+        fetch.mockReject();
+        render(<AppContextProvider><FbwPage /></AppContextProvider>);
+        await advanceToChecking();
+        expect(await screen.findByText('You should try to connect to the network ournetwork/mynode'));
+    });
+
+    it('asks to connect to the wifi network for this node if getting different hostname ', async () => {
+        fetch.mockResponse('anothernode\n');
+        render(<AppContextProvider><FbwPage /></AppContextProvider>);
+        await advanceToChecking();
+        expect(await screen.findByText('You are connected to another node in the network, try connecting to ournetwork/mynode'));
+    });
+})

--- a/plugins/lime-plugin-fbw/src/containers/NetworkForm.js
+++ b/plugins/lime-plugin-fbw/src/containers/NetworkForm.js
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import { useState } from 'preact/hooks';
 
-import '../style';
+import '../style.less';
 
 import { Trans, t } from '@lingui/macro';
 import { isValidHostname, slugify } from 'utils/isValidHostname';
@@ -70,18 +70,18 @@ export const NetworkForm = ({toggleForm}) => {
 
 	return (<div class="container container-padded">
 		<h4><span><Trans>Configure your new community network</Trans></span></h4>
-		<label><Trans>Choose a name for your network</Trans></label>
-		<input type="text" placeholder={t`Community name`} class="u-full-width" onInput={_changeName} />
-		<label><Trans>Choose a shared password for network administration</Trans></label>
-		<input type="password" placeholder={t`Password`} class="u-full-width" value={state.password} onInput={_changePassword} />
+		<label for="community_name" ><Trans>Choose a name for your network</Trans></label>
+		<input id="community_name" type="text" placeholder={t`Community name`} class="u-full-width" onInput={_changeName} />
+		<label for="shared_password"><Trans>Choose a shared password for network administration</Trans></label>
+		<input id="shared_password" type="password" placeholder={t`Password`} class="u-full-width" value={state.password} onInput={_changePassword} />
 		<ValidationMessages password={state.password} />
-		<label><Trans>Re-enter the shared password</Trans></label>
-		<input type="password" placeholder={t`Re-enter Password`} class="u-full-width" value={state.passwordConfirmation} onInput={_changePasswordConfirmation} />
+		<label for="shared_password_confirm"><Trans>Re-enter the shared password</Trans></label>
+		<input id="shared_password_confirm" type="password" placeholder={t`Re-enter Password`} class="u-full-width" value={state.passwordConfirmation} onInput={_changePasswordConfirmation} />
 		{state.passwordConfirmation && state.password !== state.passwordConfirmation &&
 			<p><Trans>The passwords do not match!</Trans></p>
 		}
-		<label><Trans>Choose a name for this node</Trans></label>
-		<input type="text" placeholder={t`Host name`} class="u-full-width" value={state.hostName} onInput={_changeHostName} />
+		<label for="hostname"><Trans>Choose a name for this node</Trans></label>
+		<input id="hostname" type="text" placeholder={t`Host name`} class="u-full-width" value={state.hostName} onInput={_changeHostName} />
 		<div class="row">
 			<div class="six columns">
 				<button

--- a/plugins/lime-plugin-fbw/src/containers/Scan.js
+++ b/plugins/lime-plugin-fbw/src/containers/Scan.js
@@ -1,7 +1,7 @@
 import { h } from 'preact';
 import { useState, useEffect } from 'preact/hooks';
 
-import '../style';
+import '../style.less';
 
 import { Trans, t } from '@lingui/macro';
 import { Loading } from 'components/loading';

--- a/plugins/lime-plugin-fbw/src/containers/Setting.js
+++ b/plugins/lime-plugin-fbw/src/containers/Setting.js
@@ -2,7 +2,7 @@ import { h } from 'preact';
 import { useState } from 'preact/hooks';
 import { Trans } from '@lingui/macro';
 
-import '../style';
+import '../style.less';
 
 import ProgressBar from 'components/progressbar';
 import Loading from 'components/loading';
@@ -57,8 +57,8 @@ export const Setting = ({ expectedHost, expectedNetwork, delay=1000 }) => {
 	}
 
 	function runProgress (totalTime, cb) {
-		if (time > 0) setTime(time - 1);
-		if (progress < 100) setProgress(progress + (100/totalTime));
+		if (time > 0) setTime(time => time - 1);
+		if (progress < 100) setProgress(progress => progress + (100/totalTime));
 		if (time <= 1) cb();
 	}
 

--- a/src/utils/app.context.js
+++ b/src/utils/app.context.js
@@ -1,4 +1,5 @@
 /* eslint-disable react/sort-comp */
+import { h } from "preact";
 import { createContext, Component } from 'preact';
 import { useContext } from 'preact/hooks';
 


### PR DESCRIPTION
Hi @selankon I've found a small bug while testing your branch in a LR, it's due to setExpectedHost/Network not being called after network creation. In the previous version this was done [here](https://github.com/libremesh/lime-app/blob/c7806cdf3bc26c13db589d6630c03f45a6800713/plugins/lime-plugin-fbw/src/reducer.js#L61)

This PR adds a (failing) test suite that should pass when the bug gets fixed.
It's a tricky testing scenario because it involves fake timers, promise flushing, but... there it is.
Some minor changes to the code base where needed for the tests to workout. Some of them have better solutions.

You can run the tests with:
`npm run test -- -t 'Fbw Page'`